### PR TITLE
Support file uploads.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Fully-featured GraphQL Server with focus on easy setup, performance &amp; great 
 `graphql-yoga` is based on the following libraries & tools:
 
   * [`express`](https://github.com/expressjs/express)/[`apollo-server`](https://github.com/apollographql/apollo-server): Performant, extensible web server framework
+  * [`apollo-upload-server`](https://github.com/jaydenseric/apollo-upload-server): File uploads via queries or mutations
   * [`graphql-subscriptions`](https://github.com/apollographql/graphql-subscriptions)/[`subscriptions-transport-ws`](https://github.com/apollographql/subscriptions-transport-ws): GraphQL subscriptions server
   * [`graphql.js`](https://github.com/graphql/graphql-js)/[`graphql-tools`](https://github.com/apollographql/graphql-tools): GraphQL engine & schema helpers
   * [`graphql-playground`](https://github.com/graphcool/graphql-playground): Interactive GraphQL IDE
@@ -102,6 +103,7 @@ The `options` object has the following fields:
 - `subscriptionsEndpoint`: A **string** that defines the subscriptions (websocket) endpoint for your server **(default: `'/'`)**.
 - `playgroundEndpoint`: A **string** that defines the endpoint where you can invoke the Playground **(default: `'/'`)**.
 - `disablePlayground`: A **boolean** indicating whether the Playground should be enabled **(default: `false`)**.
+- `uploads`: An **object** containing [configuration options](https://github.com/jaydenseric/apollo-upload-server#options) for [apollo-upload-server](https://github.com/jaydenseric/apollo-upload-server).
 
 ### `GraphQLServer.start()`
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@types/zen-observable": "^0.5.3",
     "apollo-link": "^1.0.3",
     "apollo-server-express": "^1.2.0",
+    "apollo-upload-server": "^4.0.0-alpha.1",
     "cors": "^2.8.4",
     "express": "^4.16.2",
     "graphql": "^0.11.7",

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,12 @@ export interface ContextParameters {
 
 export type ContextCallback = (params: ContextParameters) => Context
 
+export interface UploadOptions {
+  maxFieldSize?: number
+  maxFileSize?: number
+  maxFiles?: number
+}
+
 export interface Options {
   cors?: CorsOptions | false
   disableSubscriptions?: boolean
@@ -35,6 +41,7 @@ export interface Options {
   subscriptionsEndpoint?: string
   playgroundEndpoint?: string
   disablePlayground?: boolean
+  uploads?: UploadOptions
 }
 
 export interface Props {


### PR DESCRIPTION
Support file uploads via queries or mutations with apollo-upload-server. Fixes https://github.com/graphcool/graphql-yoga/issues/1.

@schickling I haven't tested this out, but it should get the ball rolling 🙂