### PR TITLE
Changes to make `graphql-yoga` more extendable

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,11 +207,14 @@ Whenever the defaults of `graphql-yoga` are too tight of a corset for you, you c
 The core value of `graphql-yoga` is that you don't have to write the boilerplate required to configure your [express.js](https://github.com/expressjs/) application. However, once you need to add more customized behaviour to your server, the default configuration provided by `graphql-yoga` might not suit your use case any more. For example, it might be the case that you want to add more custom _middleware_ to your server, like for logging or error reporting.
 
 For these cases, `GraphQLServer` exposes the `express.Application` directly via its [`express`](./src/index.ts#L17) property:
-
 ```js
 server.express.use(myMiddleware())
 ```
-
+Middlewares can also be added specifically to the GraphQL endpoint route, by using:
+```js
+server.express.post(server.options.endpoint, myMiddleware())
+```
+Any middlewares you add to that route, will be added right before the `apollo-server-express` middleware.
 
 ## Help & Community [![Slack Status](https://slack.graph.cool/badge.svg)](https://slack.graph.cool)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ export class GraphQLServer {
 
   protected executableSchema: GraphQLSchema
   protected context: any
-  protected options: Options
+  public options: Options
 
   constructor(props: Props) {
     const defaultOptions: Options = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,8 +16,8 @@ export class GraphQLServer {
   express: express.Application
   subscriptionServer: SubscriptionServer | null
   options: Options
+  executableSchema: GraphQLSchema
 
-  protected executableSchema: GraphQLSchema
   protected context: any
 
   constructor(props: Props) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,16 +37,16 @@ export class GraphQLServer {
     }
 
     this.express = express()
-    
+
     // CORS support
     if (this.options.cors) {
       this.express.use(cors(this.options.cors))
     } else if (this.options.cors !== false) {
       this.express.use(cors())
     }
-    
+
     this.express.post(this.options.endpoint, express.json(), apolloUploadExpress(this.options.uploads))
-    
+
     this.subscriptionServer = null
     this.context = props.context
 
@@ -111,7 +111,7 @@ export class GraphQLServer {
 
       app.get(playgroundEndpoint, expressPlayground(playgroundOptions))
     }
-     
+
     if (!this.executableSchema) {
       throw new Error('No schema defined')
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,10 +15,10 @@ export { Options }
 export class GraphQLServer {
   express: express.Application
   subscriptionServer: SubscriptionServer | null
+  options: Options
 
   protected executableSchema: GraphQLSchema
   protected context: any
-  public options: Options
 
   constructor(props: Props) {
     const defaultOptions: Options = {


### PR DESCRIPTION
- Change `context` and `options` modifier from `private` to `protected` so they can be read in derived classes
- Allow initialization without schema or typeDefs/resolvers + error handling
- Moved `cors`, `bodyParser` and `apolloUpload` from `start` to constructor, so additional middlewares are added in the right place before `start` is called
- Renames backing property `schema` to `executableSchema` to avoid confusion because the `GraphQLSchema` type doesn't guarantee that the schema is actually executable. Also made it `protected` because it is not designed to be set manually for normal usage. This is technically a breaking change, but as I didn't change the constructor parameter `schema`, it should be okay.