### PR TITLE
chore(renovate): automerge examples/* dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,10 @@
 {
-  "extends": [
-    "config:base",
-    ":pathSemanticCommitType(examples/**,chore)"
+  "extends": ["config:base"],
+  "pathRules": [
+    {
+      "paths": ["examples/**"],
+      "extends": [":semanticCommitTypeAll(chore)", ":automergeMajor"],
+      "branchName": "{{branchPrefix}}examples-{{depNameSanitized}}-{{newVersionMajor}}.x"
+    }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,7 @@
   "pathRules": [
     {
       "paths": ["examples/**"],
-      "extends": [":semanticCommitTypeAll(chore)", ":automergeMajor"],
+      "extends": [":semanticCommitTypeAll(chore)", ":automergeMinor"],
       "branchName": "{{branchPrefix}}examples-{{depNameSanitized}}-{{newVersionMajor}}.x"
     }
   ]


### PR DESCRIPTION
Updates `renovate.json` to add a rule to automerge any Renovate PR targeting `examples/*` directories. Adds an `examples-` prefix to the branchName to ensure that examples branches remain separate from the rest of the project.

Closes #61