### PR TITLE
Improved Readme for file-upload example

### DIFF
--- a/examples/file-upload/README.md
+++ b/examples/file-upload/README.md
@@ -1,5 +1,23 @@
 # file-upload
 
-*WIP*
+This directory contains an example of a graql-yoga server supporting file uploads.
 
-- needs CURL & frontend example
+## Get started
+
+**Clone the repository:**
+
+```sh
+git clone https://github.com/graphcool/graphql-yoga/
+cd graphql-yoga/examples/file-upload
+```
+
+**Install dependencies and run the app:**
+
+```sh
+yarn install # or npm install
+yarn start   # or npm start
+```
+
+## Using the file-upload api
+
+The graphql-yoga server uses [apollo-upload-server](https://github.com/jaydenseric/apollo-upload-server) to handle file uploads. It expects files to be uploaded through a specific [GraphQL multi-part request](https://github.com/jaydenseric/graphql-multipart-request-spec). The simplest way to correctly handle the outgoing request is to use [apollo-upload-client](https://github.com/jaydenseric/apollo-upload-client). See [apollo-upload-examples](https://github.com/jaydenseric/apollo-upload-examples) for a react client uploading to apollo-upload-server similar in function to the one here.

--- a/examples/file-upload/index.ts
+++ b/examples/file-upload/index.ts
@@ -73,4 +73,4 @@ const resolvers = {
 
 const server = new GraphQLServer({ typeDefs, resolvers })
 
-server.start(() => console.log('Server is running on localhost:4000'))
+server.start(() => console.log('Server is running on http://localhost:4000'))


### PR DESCRIPTION
Some detailed examples can be added later, but this provides some useful clues about what we are looking at and how to get started.

Using curl with apollo-upload-server is especially tricky, so it might not actually be so useful.