### PR TITLE
Remove `apollo-link`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "@types/express": "^4.0.39",
     "@types/graphql": "^0.11.8",
     "@types/zen-observable": "^0.5.3",
-    "apollo-link": "^1.0.7",
     "apollo-server-express": "^1.3.2",
     "apollo-server-lambda": "1.3.2",
     "apollo-upload-server": "^4.0.0-alpha.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -96,7 +96,7 @@ apollo-cache-control@^0.0.x:
   dependencies:
     graphql-extensions "^0.0.x"
 
-apollo-link@^1.0.0, apollo-link@^1.0.7:
+apollo-link@^1.0.0:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/apollo-link/-/apollo-link-1.0.7.tgz#42cd38a7378332fc3e41a214ff6a6e5e703a556f"
   dependencies:


### PR DESCRIPTION
It doesn't seem to be used.  `graphql-tools` uses it, though.