### PR TITLE
Provide authorization token to the subscription context to be able to…

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ The `props` argument accepts the following fields:
 > 1. Provide `typeDefs` and `resolvers` and omit the `schema`, in this case `graphql-yoga` will construct the `GraphQLSchema` instance using [`makeExecutableSchema`](https://www.apollographql.com/docs/graphql-tools/generate-schema.html#makeExecutableSchema) from [`graphql-tools`](https://github.com/apollographql/graphql-tools).
 > 2. Provide the `schema` directly and omit `typeDefs` and `resolvers`.
 
-> (\*\*) Notice that the `req` argument is an object of the shape `{ request, connection }` which either carries a `request: Request` property (in case it's a `Query`/`Mutation` resolver) or a `connection: SubscriptionOptions` property (in case it's a `Subscription` resolver). [`Request`](http://expressjs.com/en/api.html#req) is imported from Express.js. `SubscriptionOptions` is from the [`graphql-subscriptions`](https://github.com/apollographql/graphql-subscriptions) package.
+> (\*\*) Notice that the `req` argument is an object of the shape `{ request, connection }` which either carries a `request: Request` property (in case it's a `Query`/`Mutation` resolver) or a `connection: SubscriptionOptions` property (in case it's a `Subscription` resolver). [`Request`](http://expressjs.com/en/api.html#req) is imported from Express.js. `SubscriptionOptions` is from the [`graphql-subscriptions`](https://github.com/apollographql/graphql-subscriptions) package. `SubscriptionOptions` are getting the connectionParams automatically injected under `SubscriptionOptions.context.[CONNECTION_PARAMETER_NAME]`
 
 Here is example of creating a new server:
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -239,6 +239,9 @@ export class GraphQLServer {
             schema: this.executableSchema,
             execute,
             subscribe,
+            onConnect: async (connectionParams, webSocket) => {
+              return { ...connectionParams }
+            },
             onOperation: async (message, connection, webSocket) => {
               let context
               try {


### PR DESCRIPTION
I created a PR to be able to identify the user later in my subscription resolvers.
This PR is more like a working proposal but should be discussed.

What i am doing is to forward the connection parameters to the connection context. So i can access my authorization token in my resolvers.

Here an example how it would work with prisma but in other cases with graphql-yoga too:

```typescript
dashboard: {
  subscribe: (parent, args, ctx: Context, info) => {
    const userId = getUserId(ctx);
    ...
    return ctx.pubsub.asyncIterator(channel);
  }
}

export function getUserId(ctx: Context) {
  const Authorization = ctx.request
    ? ctx.request.get('Authorization')
    : ctx.connection.context.Authorization;
  if (Authorization) {
    const token = Authorization.replace('Bearer ', '');
    const { userId } = jwt.verify(token, process.env.APP_SECRET) as { userId: string };
    return userId;
  }

  throw new AuthError();
}
```

What should be discussed?
In my PR all connection parameters are forwarded. I don't know if this is ok but keeps us flexible too.

How do you like it? Any suggestions how this could be improved?

Best regards
