### PR TITLE
Code Cleaning: Update index.ts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -56,9 +56,7 @@ export class GraphQLServer {
 
       // read from .graphql file if path provided
       if (typeDefs.endsWith('graphql')) {
-        const schemaPath = path.isAbsolute(typeDefs)
-          ? path.resolve(typeDefs)
-          : path.resolve(typeDefs)
+        const schemaPath = path.resolve(typeDefs)
 
         if (!fs.existsSync(schemaPath)) {
           throw new Error(`No schema found for path: ${schemaPath}`)


### PR DESCRIPTION
When checking across the graphql-yoga code because I had problems when setting up an apollo-server with Node.js, because the graphQL schema location was not properly set, I found this unuseful ternary operator.