### PR TITLE
fix(Upload): remove duplicated apolloUploadExpress middleware

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -142,7 +142,6 @@ export class GraphQLServer {
     app.post(
       this.options.endpoint,
       bodyParser.graphql(),
-      apolloUploadExpress(this.options.uploads),
     )
 
     if (this.options.uploads) {


### PR DESCRIPTION
There are two `apolloUploadExpress`  middlewares