### PR TITLE
feat: suport array syntax for typeDefs argument

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,6 @@ import * as path from 'path'
 import { SubscriptionServer } from 'subscriptions-transport-ws'
 
 import { SubscriptionServerOptions, Options, Props } from './types'
-import { ITypeDefinitions } from 'graphql-tools/dist/Interfaces'
 
 import { defaultErrorFormatter } from './defaultErrorFormatter';
 
@@ -57,19 +56,6 @@ export class GraphQLServer {
     } else if (props.typeDefs && props.resolvers) {
       let uploadMixin = {}
       let { directiveResolvers, resolvers, typeDefs } = props
-
-      if (Array.isArray(typeDefs)) {
-        const toSingleTypedef = (previousValue: string, typeDef: ITypeDefinitions ): string => {
-          let currentValue = typeof typeDef === 'function' ? typeDef() : typeDef
-          let accumulator = Array.isArray(currentValue)
-            ? currentValue.reduce(toSingleTypedef, '')
-            : currentValue
-
-          return previousValue + accumulator
-        }
-
-        typeDefs = typeDefs.reduce(toSingleTypedef, '')
-      }
 
       if (typeof typeDefs === 'string') {
         // read from .graphql file if path provided

--- a/src/lambda.ts
+++ b/src/lambda.ts
@@ -28,17 +28,19 @@ export class GraphQLServerLambda {
     } else if (props.typeDefs && props.resolvers) {
       let { directiveResolvers, typeDefs, resolvers } = props
 
-      // read from .graphql file if path provided
-      if (typeDefs.endsWith('graphql')) {
-        const schemaPath = path.isAbsolute(typeDefs)
-          ? path.resolve(typeDefs)
-          : path.resolve(typeDefs)
+      if (typeof typeDefs === 'string') {
+        // read from .graphql file if path provided
+        if (typeDefs.endsWith('graphql')) {
+            const schemaPath = path.isAbsolute(typeDefs)
+                ? path.resolve(typeDefs)
+                : path.resolve(typeDefs)
 
-        if (!fs.existsSync(schemaPath)) {
-          throw new Error(`No schema found for path: ${schemaPath}`)
+            if (!fs.existsSync(schemaPath)) {
+                throw new Error(`No schema found for path: ${schemaPath}`)
+            }
+
+            typeDefs = importSchema(schemaPath)
         }
-
-        typeDefs = importSchema(schemaPath)
       }
 
       this.executableSchema = makeExecutableSchema({

--- a/src/lambda.ts
+++ b/src/lambda.ts
@@ -28,19 +28,17 @@ export class GraphQLServerLambda {
     } else if (props.typeDefs && props.resolvers) {
       let { directiveResolvers, typeDefs, resolvers } = props
 
-      if (typeof typeDefs === 'string') {
-        // read from .graphql file if path provided
-        if (typeDefs.endsWith('graphql')) {
-            const schemaPath = path.isAbsolute(typeDefs)
-                ? path.resolve(typeDefs)
-                : path.resolve(typeDefs)
+      // read from .graphql file if path provided
+      if (typeDefs.endsWith('graphql')) {
+        const schemaPath = path.isAbsolute(typeDefs)
+          ? path.resolve(typeDefs)
+          : path.resolve(typeDefs)
 
-            if (!fs.existsSync(schemaPath)) {
-                throw new Error(`No schema found for path: ${schemaPath}`)
-            }
-
-            typeDefs = importSchema(schemaPath)
+        if (!fs.existsSync(schemaPath)) {
+          throw new Error(`No schema found for path: ${schemaPath}`)
         }
+
+        typeDefs = importSchema(schemaPath)
       }
 
       this.executableSchema = makeExecutableSchema({

--- a/src/types.ts
+++ b/src/types.ts
@@ -83,7 +83,7 @@ export interface Props {
 
 export interface LambdaProps {
   directiveResolvers?: IDirectiveResolvers<any, any>
-  typeDefs?: string
+  typeDefs?: ITypeDefinitions
   resolvers?: IResolvers
   schema?: GraphQLSchema
   context?: Context | ContextCallback

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,7 +8,7 @@ import {
   GraphQLTypeResolver,
   ValidationContext,
 } from 'graphql'
-import { IDirectiveResolvers } from 'graphql-tools/dist/Interfaces'
+import { IDirectiveResolvers, ITypeDefinitions } from 'graphql-tools/dist/Interfaces'
 import { SubscriptionOptions } from 'graphql-subscriptions/dist/subscriptions-manager'
 import { LogFunction } from 'apollo-server-core'
 
@@ -75,7 +75,7 @@ export interface SubscriptionServerOptions {
 
 export interface Props {
   directiveResolvers?: IDirectiveResolvers<any, any>
-  typeDefs?: string
+  typeDefs?: ITypeDefinitions
   resolvers?: IResolvers
   schema?: GraphQLSchema
   context?: Context | ContextCallback

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,11 +8,8 @@ import {
   GraphQLTypeResolver,
   ValidationContext,
 } from 'graphql'
-
 import { IDirectiveResolvers, ITypeDefinitions } from 'graphql-tools/dist/Interfaces'
-import { SubscriptionOptions } from 'graphql-subscriptions/dist/subscriptions-manager'
 import { ExecutionParams } from 'subscriptions-transport-ws'
-
 import { LogFunction } from 'apollo-server-core'
 
 export interface IResolvers {
@@ -86,7 +83,7 @@ export interface Props {
 
 export interface LambdaProps {
   directiveResolvers?: IDirectiveResolvers<any, any>
-  typeDefs?: ITypeDefinitions
+  typeDefs?: string
   resolvers?: IResolvers
   schema?: GraphQLSchema
   context?: Context | ContextCallback


### PR DESCRIPTION
This PR fixes: https://github.com/graphcool/graphql-yoga/issues/185.
Adopt `ITypeDefinitions` from `graphql-tools` for typeDefs type.
Type check before trying to verify if typeDefs is a string containing a path to import `graphql.schema`