### PR TITLE
Resolve promise with server in non-subscription case

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -233,9 +233,11 @@ export class GraphQLServer {
 
     return new Promise((resolve, reject) => {
       if (!subscriptionServerOptions) {
-        app.listen(this.options.port, () => {
+        const server = createServer(app)
+
+        server.listen(this.options.port, () => {
           callbackFunc(this.options)
-          resolve()
+          resolve(server)
         })
       } else {
         const combinedServer = createServer(app)


### PR DESCRIPTION
The signature of the Promise returned from `start` expects a `Server`, but one is not returned from the case where there is no subscription.