### PR TITLE
Expose subscription server onConnect and onDisconnect options

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ The `options` object has the following fields:
 | `tracing`  | Boolean or String  |  `'http-header'`  | Indicates whether [Apollo Tracing](https://github.com/apollographql/apollo-tracing) should be en- or disabled for your server (if a string is provided, accepted values are: `'enabled'`, `'disabled'`, `'http-header'`) |
 | `port`  | Number |  `4000`  | Determines the port your server will be listening on (note that you can also specify the port by setting the `PORT` environment variable) |
 | `endpoint`  | String  |  `'/'`  | Defines the HTTP endpoint of your server |
-| `subscriptions` | Object or String or `false`  |  `'/'`  | Defines the subscriptions (websocket) endpoint for your server; accepts an object with subscription server options `path` and `keepAlive`; setting to `false` disables subscriptions completely |
+| `subscriptions` | Object or String or `false`  |  `'/'`  | Defines the subscriptions (websocket) endpoint for your server; accepts an object with [subscription server options](https://github.com/apollographql/subscriptions-transport-ws#constructoroptions-socketoptions) `path`, `keepAlive`, `onConnect` and `onDisconnect`; setting to `false` disables subscriptions completely |
 | `playground` | String or `false` |  `'/'`  | Defines the endpoint where you can invoke the [Playground](https://github.com/graphcool/graphql-playground); setting to `false` disables the playground endpoint |
 | `uploads` | [UploadOptions](/src/types.ts#L39-L43) or `false` or `undefined`  | `null`  | Provides information about upload limits; the object can have any combination of the following three keys: `maxFieldSize`, `maxFileSize`, `maxFiles`; each of these have values of type Number; setting to `false` disables file uploading |
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -243,9 +243,10 @@ export class GraphQLServer {
             schema: this.executableSchema,
             execute,
             subscribe,
-            onConnect: async (connectionParams, webSocket) => {
-              return { ...connectionParams }
-            },
+            onConnect: subscriptionServerOptions.onConnect
+              ? subscriptionServerOptions.onConnect
+              : async (connectionParams, webSocket) => ({ ...connectionParams }),
+            onDisconnect: subscriptionServerOptions.onDisconnect,
             onOperation: async (message, connection, webSocket) => {
               let context
               try {

--- a/src/types.ts
+++ b/src/types.ts
@@ -70,6 +70,8 @@ export interface Options extends ApolloServerOptions {
 
 export interface SubscriptionServerOptions {
   path?: string
+  onConnect?: Function
+  onDisconnect?: Function
   keepAlive?: number
 }
 


### PR DESCRIPTION
I need access to onConnect for verifying the access token on a websocket connection.  Then I need access to onDisconnect to perform some clean up when a websocket disconnects.