### PR TITLE
Support latest Apollo Engine natively

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Fully-featured GraphQL Server with focus on easy setup, performance & great deve
   * [`graphql-subscriptions`](https://github.com/apollographql/graphql-subscriptions)/[`subscriptions-transport-ws`](https://github.com/apollographql/subscriptions-transport-ws): GraphQL subscriptions server
   * [`graphql.js`](https://github.com/graphql/graphql-js)/[`graphql-tools`](https://github.com/apollographql/graphql-tools): GraphQL engine & schema helpers
   * [`graphql-playground`](https://github.com/graphcool/graphql-playground): Interactive GraphQL IDE
+  * [`apollo-engine`](https://github.com/apollographql/apollo-engine-js): Delivers essential capabilities like query caching, error tracking, automatic persisted queries, and execution tracing.
 
 ## Features
 
@@ -28,6 +29,7 @@ Fully-featured GraphQL Server with focus on easy setup, performance & great deve
 * GraphQL Playground
 * Extensible via Express middlewares
 * Apollo Tracing
+* Apollo Engine integration
 * Accepts both `application/json` and `application/graphql` content-type
 * Runs everywhere: Can be deployed via `now`, `up`, AWS Lambda, Heroku etc
 
@@ -119,6 +121,7 @@ The `options` object has the following fields:
 | `subscriptions` | Object or String or `false`  |  `'/'`  | Defines the subscriptions (websocket) endpoint for your server; accepts an object with [subscription server options](https://github.com/apollographql/subscriptions-transport-ws#constructoroptions-socketoptions) `path`, `keepAlive`, `onConnect` and `onDisconnect`; setting to `false` disables subscriptions completely |
 | `playground` | String or `false` |  `'/'`  | Defines the endpoint where you can invoke the [Playground](https://github.com/graphcool/graphql-playground); setting to `false` disables the playground endpoint |
 | `uploads` | [UploadOptions](/src/types.ts#L39-L43) or `false` or `undefined`  | `null`  | Provides information about upload limits; the object can have any combination of the following three keys: `maxFieldSize`, `maxFileSize`, `maxFiles`; each of these have values of type Number; setting to `false` disables file uploading |
+| `apolloEngine` | `string` or `object` | `null` | A string API key for Apollo Engine, or an object of Apollo Engine options, including `apiKey`, for proxying through Apollo Engine. You should also set `tracing` and `cacheControl` options accordingly. |
 
 Additionally, the `options` object exposes these `apollo-server` options:
 
@@ -153,11 +156,12 @@ See the original documentation in [`graphql-subscriptions`](https://github.com/a
 
 ## Examples
 
-There are three examples demonstrating how to quickly get started with `graphql-yoga`:
+There are four examples demonstrating how to quickly get started with `graphql-yoga`:
 
 - [hello-world](./examples/hello-world): Basic setup for building a schema and allowing for a `hello` query.
 - [subscriptions](./examples/subscriptions): Basic setup for using subscriptions with a counter that increments every 2 seconds and triggers a subscriptions.
 - [fullstack](./examples/fullstack): Fullstack example based on [`create-react-app`](https://github.com/facebookincubator/create-react-app) demonstrating how to query data from `graphql-yoga` with [Apollo Client 2.0](https://www.apollographql.com/client/).
+- [apollo-engine](./examples/apollo-engine): Basic setup for integrating with Apollo Engine.
 
 ## Workflow
 

--- a/examples/apollo-engine/README.md
+++ b/examples/apollo-engine/README.md
@@ -76,11 +76,8 @@ The server returns the following response:
 This is what the [implementation](./index.js) looks like:
 
 ```js
-import { GraphQLServer } from './graphql-yoga'
-import { Engine } from 'apollo-engine'
-// ... or using `require()`
-// const { GraphQLServer } = require('graphql-yoga')
-// const { Engine } = require('apollo-engine')
+const { GraphQLServer } = require('graphql-yoga')
+const compression = require('compression')
 
 const typeDefs = `
   type Query {
@@ -96,14 +93,13 @@ const resolvers = {
 
 const server = new GraphQLServer({ typeDefs, resolvers })
 
-const engine = new Engine({
-  engineConfig: { apiKey: process.env.APOLLO_ENGINE_KEY },
-  endpoint: '/',
-  graphqlPort: parseInt(process.env.Port, 10) || 4000,
-})
-engine.start();
+// Enable gzip compression
+// ref: https://www.apollographql.com/docs/engine/setup-node.html#enabling-compression
+server.express.use(compression())
 
-server.express.use(engine.expressMiddleware())
-
-server.start(() => console.log('Server is running on localhost:4000'))
+server.start({
+  apolloEngine: process.env.APOLLO_ENGINE_KEY,
+  tracing: true,
+  cacheControl: true
+}, () => console.log('Server is running on localhost:4000'))
 ```

--- a/examples/apollo-engine/index.js
+++ b/examples/apollo-engine/index.js
@@ -1,5 +1,4 @@
 const { GraphQLServer } = require('graphql-yoga')
-const { Engine } = require('apollo-engine')
 const compression = require('compression')
 
 const typeDefs = `
@@ -15,19 +14,12 @@ const resolvers = {
 
 const server = new GraphQLServer({ typeDefs, resolvers })
 
-const engine = new Engine({
-  engineConfig: { apiKey: process.env.APOLLO_ENGINE_KEY },
-  endpoint: '/',
-  graphqlPort: parseInt(process.env.Port, 10) || 4000,
-})
-engine.start()
-
 // Enable gzip compression
 // ref: https://www.apollographql.com/docs/engine/setup-node.html#enabling-compression
 server.express.use(compression())
-server.express.use(engine.expressMiddleware())
 
 server.start({
+  apolloEngine: process.env.APOLLO_ENGINE_KEY,
   tracing: true,
   cacheControl: true
 }, () => console.log('Server is running on localhost:4000'))

--- a/examples/apollo-engine/package.json
+++ b/examples/apollo-engine/package.json
@@ -3,8 +3,8 @@
     "start": "node ."
   },
   "dependencies": {
-    "apollo-engine": "0.8.5",
-    "compression": "1.7.1",
-    "graphql-yoga": "1.2.0"
+    "apollo-engine": "1.0.1",
+    "compression": "1.7.2",
+    "graphql-yoga": "1.6.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,10 +33,16 @@
     "branch": "master"
   },
   "dependencies": {
+    "@types/connect": "^3.4.31",
     "@types/cors": "^2.8.3",
     "@types/express": "^4.0.39",
     "@types/graphql": "^0.12.0",
+    "@types/koa": "^2.0.44",
+    "@types/koa-bodyparser": "^4.2.0",
+    "@types/koa-router": "^7.0.27",
+    "@types/restify": "^5.0.7",
     "@types/zen-observable": "^0.5.3",
+    "apollo-engine": "^1.0.1",
     "apollo-server-express": "^1.3.2",
     "apollo-server-lambda": "1.3.2",
     "apollo-upload-server": "^4.0.0-alpha.1",

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,7 @@ import {
 import { IDirectiveResolvers, ITypeDefinitions } from 'graphql-tools/dist/Interfaces'
 import { ExecutionParams } from 'subscriptions-transport-ws'
 import { LogFunction } from 'apollo-server-core'
+import { EngineConfig } from 'apollo-engine/lib/types'
 
 export interface IResolvers {
   [key: string]: (() => any) | IResolverObject | GraphQLScalarType
@@ -49,6 +50,7 @@ export interface TracingOptions {
 export interface ApolloServerOptions {
   tracing?: boolean | TracingOptions
   cacheControl?: boolean
+  apolloEngine?: EngineConfig,
   formatError?: Function
   logFunction?: LogFunction
   rootValue?: any

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,12 @@
 # yarn lockfile v1
 
 
+"@types/accepts@*":
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/@types/accepts/-/accepts-1.3.5.tgz#c34bec115cfc746e04fe5a059df4ce7e7b391575"
+  dependencies:
+    "@types/node" "*"
+
 "@types/aws-lambda@0.0.33":
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/@types/aws-lambda/-/aws-lambda-0.0.33.tgz#17083d9c569048792f4f33ef6cd6aaf54d5b22d3"
@@ -13,11 +19,37 @@
     "@types/express" "*"
     "@types/node" "*"
 
+"@types/bunyan@*":
+  version "1.8.4"
+  resolved "https://registry.yarnpkg.com/@types/bunyan/-/bunyan-1.8.4.tgz#69c11adc7b50538d45fb68d9ae39d062b9432f38"
+  dependencies:
+    "@types/events" "*"
+    "@types/node" "*"
+
+"@types/connect@*", "@types/connect@^3.4.31":
+  version "3.4.31"
+  resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.31.tgz#1f92d6b117ecc05076c49ecd024f7976e528bad9"
+  dependencies:
+    "@types/node" "*"
+
+"@types/cookies@*":
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/@types/cookies/-/cookies-0.7.1.tgz#f9f204bd6767d389eea3b87609e30c090c77a540"
+  dependencies:
+    "@types/connect" "*"
+    "@types/express" "*"
+    "@types/keygrip" "*"
+    "@types/node" "*"
+
 "@types/cors@^2.8.3":
   version "2.8.3"
   resolved "https://registry.yarnpkg.com/@types/cors/-/cors-2.8.3.tgz#eaf6e476da0d36bee6b061a24d57e343ddce86d6"
   dependencies:
     "@types/express" "*"
+
+"@types/events@*":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@types/events/-/events-1.2.0.tgz#81a6731ce4df43619e5c8c945383b3e62a89ea86"
 
 "@types/express-serve-static-core@*":
   version "4.0.56"
@@ -37,6 +69,42 @@
   version "0.12.4"
   resolved "https://registry.yarnpkg.com/@types/graphql/-/graphql-0.12.4.tgz#d43bb55d45c6de0178bbd11dd59d04fd42138d94"
 
+"@types/http-assert@*":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@types/http-assert/-/http-assert-1.2.2.tgz#17dfe5a82184a8898935d96fe2eaedd37d22d9a4"
+
+"@types/keygrip@*":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@types/keygrip/-/keygrip-1.0.1.tgz#ff540462d2fb4d0a88441ceaf27d287b01c3d878"
+
+"@types/koa-bodyparser@^4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@types/koa-bodyparser/-/koa-bodyparser-4.2.0.tgz#04febc567f3d3dd40e3d1a0e095cdf7b07c4d7ce"
+  dependencies:
+    "@types/koa" "*"
+
+"@types/koa-compose@*":
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/@types/koa-compose/-/koa-compose-3.2.2.tgz#dc106e000bbf92a3ac900f756df47344887ee847"
+
+"@types/koa-router@^7.0.27":
+  version "7.0.27"
+  resolved "https://registry.yarnpkg.com/@types/koa-router/-/koa-router-7.0.27.tgz#4993d50cb9efdfcfb11f16c726a4b34f8fb3e0d4"
+  dependencies:
+    "@types/koa" "*"
+
+"@types/koa@*", "@types/koa@^2.0.44":
+  version "2.0.44"
+  resolved "https://registry.yarnpkg.com/@types/koa/-/koa-2.0.44.tgz#4d972a3dec4d6eb89bd3c16775de26305d1c51a6"
+  dependencies:
+    "@types/accepts" "*"
+    "@types/cookies" "*"
+    "@types/events" "*"
+    "@types/http-assert" "*"
+    "@types/keygrip" "*"
+    "@types/koa-compose" "*"
+    "@types/node" "*"
+
 "@types/mime@*":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-2.0.0.tgz#5a7306e367c539b9f6543499de8dd519fac37a8b"
@@ -45,12 +113,26 @@
   version "8.0.52"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.52.tgz#8e7f47747868e7687f2cd4922966e2d6af78d22d"
 
+"@types/restify@^5.0.7":
+  version "5.0.7"
+  resolved "https://registry.yarnpkg.com/@types/restify/-/restify-5.0.7.tgz#09b736ad96af04814f9501b7b50e84dabcd77228"
+  dependencies:
+    "@types/bunyan" "*"
+    "@types/node" "*"
+    "@types/spdy" "*"
+
 "@types/serve-static@*":
   version "1.13.1"
   resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.13.1.tgz#1d2801fa635d274cd97d4ec07e26b21b44127492"
   dependencies:
     "@types/express-serve-static-core" "*"
     "@types/mime" "*"
+
+"@types/spdy@*":
+  version "3.4.4"
+  resolved "https://registry.yarnpkg.com/@types/spdy/-/spdy-3.4.4.tgz#3282fd4ad8c4603aa49f7017dd520a08a345b2bc"
+  dependencies:
+    "@types/node" "*"
 
 "@types/zen-observable@0.5.3", "@types/zen-observable@^0.5.3":
   version "0.5.3"
@@ -82,6 +164,26 @@ apollo-cache-control@^0.0.x:
   resolved "https://registry.yarnpkg.com/apollo-cache-control/-/apollo-cache-control-0.0.7.tgz#ffef56413a429a1ce204be5b78d248c4fe3b67ac"
   dependencies:
     graphql-extensions "^0.0.x"
+
+apollo-engine-binary-darwin@0.2018.2-111-gb13195fb0:
+  version "0.2018.2-111-gb13195fb0"
+  resolved "https://registry.yarnpkg.com/apollo-engine-binary-darwin/-/apollo-engine-binary-darwin-0.2018.2-111-gb13195fb0.tgz#5e5fcbde78a5c6ad818b07ea7c850c5024b70f97"
+
+apollo-engine-binary-linux@0.2018.2-111-gb13195fb0:
+  version "0.2018.2-111-gb13195fb0"
+  resolved "https://registry.yarnpkg.com/apollo-engine-binary-linux/-/apollo-engine-binary-linux-0.2018.2-111-gb13195fb0.tgz#fede5c64dacd117012f81734f317ff60554d78ab"
+
+apollo-engine-binary-windows@0.2018.2-111-gb13195fb0:
+  version "0.2018.2-111-gb13195fb0"
+  resolved "https://registry.yarnpkg.com/apollo-engine-binary-windows/-/apollo-engine-binary-windows-0.2018.2-111-gb13195fb0.tgz#cd0a01af2842946fcb0733c125ff7bd6b3e11548"
+
+apollo-engine@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/apollo-engine/-/apollo-engine-1.0.1.tgz#a3c4ed0318754bc2ce23bc088f108ca87c26988e"
+  optionalDependencies:
+    apollo-engine-binary-darwin "0.2018.2-111-gb13195fb0"
+    apollo-engine-binary-linux "0.2018.2-111-gb13195fb0"
+    apollo-engine-binary-windows "0.2018.2-111-gb13195fb0"
 
 apollo-link@^1.0.0:
   version "1.0.7"


### PR DESCRIPTION
With the latest Apollo Engine release, it's quite hard to integrate with graphql-yoga since Apollo Engine wants to be the one to call `server.listen` instead. This feature works around having to push that on the developer by baking in native support for Apollo Engine!

The new option `apolloEngine` takes a string or object, which is passed off to the `ApolloEngine` constructor, which is either an API key or an object which specifies the API key and other options.