### PR TITLE
Upgrade apollo-engine to 1.0.1

### DIFF
--- a/examples/apollo-engine/index.js
+++ b/examples/apollo-engine/index.js
@@ -1,6 +1,5 @@
 const { GraphQLServer, PubSub } = require("graphql-yoga");
 const { ApolloEngine } = require("apollo-engine");
-const compression = require("compression");
 
 const typeDefs = `
   type Query {
@@ -51,10 +50,6 @@ const start = async () => {
   const engine = new ApolloEngine({
     apiKey: process.env.APOLLO_ENGINE_KEY
   });
-
-  // Enable gzip compression
-  // ref: https://www.apollographql.com/docs/engine/setup-node.html#enabling-compression
-  // server.express.use(compression())
 
   const httpServer = await server.configure({
     tracing: true,

--- a/examples/apollo-engine/index.js
+++ b/examples/apollo-engine/index.js
@@ -65,4 +65,3 @@ engine.listen(
     console.log(`Server is running on http://localhost:${port}`)
 );
 
-graphQLServer.createSubscriptionServer(httpServer);

--- a/examples/apollo-engine/index.js
+++ b/examples/apollo-engine/index.js
@@ -1,5 +1,5 @@
-const { GraphQLServer, PubSub } = require("graphql-yoga");
-const { ApolloEngine } = require("apollo-engine");
+const { GraphQLServer, PubSub } = require('graphql-yoga')
+const { ApolloEngine } = require('apollo-engine')
 
 const typeDefs = `
   type Query {
@@ -14,54 +14,66 @@ const typeDefs = `
   type Subscription {
     counter: Counter!
   }
-`;
+`
 
 const resolvers = {
   Query: {
-    hello: (_, { name }) => `Hello ${name || "World"}`
+    hello: (_, { name }) => `Hello ${name || 'World'}`,
   },
   Counter: {
-    countStr: counter => `Current count: ${counter.count}`
+    countStr: counter => `Current count: ${counter.count}`,
   },
   Subscription: {
     counter: {
       subscribe: (parent, args, { pubsub }) => {
-        const channel = Math.random().toString(36).substring(2, 15); // random channel name
-        let count = 0;
+        const channel = Math.random()
+          .toString(36)
+          .substring(2, 15) // random channel name
+        let count = 0
         setInterval(
           () => pubsub.publish(channel, { counter: { count: count++ } }),
-          2000
-        );
-        return pubsub.asyncIterator(channel);
-      }
-    }
-  }
-};
+          2000,
+        )
+        return pubsub.asyncIterator(channel)
+      },
+    },
+  },
+}
 
-const pubsub = new PubSub();
-const port = parseInt(process.env.PORT, 10) || 4000;
+const pubsub = new PubSub()
+const port = parseInt(process.env.PORT, 10) || 4000
 const graphQLServer = new GraphQLServer({
   typeDefs,
   resolvers,
-  context: { pubsub }
-});
+  context: { pubsub },
+})
 
-const engine = new ApolloEngine({
-  apiKey: process.env.APOLLO_ENGINE_KEY
-});
+if (process.env.APOLLO_ENGINE_KEY) {
+  const engine = new ApolloEngine({
+    apiKey: process.env.APOLLO_ENGINE_KEY,
+  })
 
-const httpServer = graphQLServer.createHttpServer({
-  tracing: true,
-  cacheControl: true
-});
+  const httpServer = graphQLServer.createHttpServer({
+    tracing: true,
+    cacheControl: true,
+  })
 
-engine.listen(
-  {
-    port,
-    httpServer,
-    graphqlPaths: ["/"]
-  },
-  () =>
-    console.log(`Server is running on http://localhost:${port}`)
-);
-
+  engine.listen(
+    {
+      port,
+      httpServer,
+      graphqlPaths: ['/'],
+    },
+    () =>
+      console.log(
+        `Server with Apollo Engine is running on http://localhost:${port}`,
+      ),
+  )
+} else {
+  graphQLServer.start(
+    {
+      port,
+    },
+    () => console.log(`Server is running on http://localhost:${port}`),
+  )
+}

--- a/examples/apollo-engine/index.js
+++ b/examples/apollo-engine/index.js
@@ -1,33 +1,77 @@
-const { GraphQLServer } = require('graphql-yoga')
-const { Engine } = require('apollo-engine')
-const compression = require('compression')
+const { GraphQLServer, PubSub } = require("graphql-yoga");
+const { ApolloEngine } = require("apollo-engine");
+const compression = require("compression");
 
 const typeDefs = `
   type Query {
     hello(name: String): String!
-  }`
+  }
+
+  type Counter {
+    count: Int!
+    countStr: String
+  }
+
+  type Subscription {
+    counter: Counter!
+  }
+`;
 
 const resolvers = {
   Query: {
-    hello: (_, { name }) => `Hello ${name || 'World'}`,
+    hello: (_, { name }) => `Hello ${name || "World"}`
   },
-}
+  Counter: {
+    countStr: counter => `Current count: ${counter.count}`
+  },
+  Subscription: {
+    counter: {
+      subscribe: (parent, args, { pubsub }) => {
+        const channel = Math.random().toString(36).substring(2, 15); // random channel name
+        let count = 0;
+        setInterval(
+          () => pubsub.publish(channel, { counter: { count: count++ } }),
+          2000
+        );
+        return pubsub.asyncIterator(channel);
+      }
+    }
+  }
+};
 
-const server = new GraphQLServer({ typeDefs, resolvers })
+const start = async () => {
+  const pubsub = new PubSub();
+  const port = parseInt(process.env.PORT, 10) || 4000;
+  const server = new GraphQLServer({
+    typeDefs,
+    resolvers,
+    context: { pubsub }
+  });
 
-const engine = new Engine({
-  engineConfig: { apiKey: process.env.APOLLO_ENGINE_KEY },
-  endpoint: '/',
-  graphqlPort: parseInt(process.env.Port, 10) || 4000,
-})
-engine.start()
+  const engine = new ApolloEngine({
+    apiKey: process.env.APOLLO_ENGINE_KEY
+  });
 
-// Enable gzip compression
-// ref: https://www.apollographql.com/docs/engine/setup-node.html#enabling-compression
-server.express.use(compression())
-server.express.use(engine.expressMiddleware())
+  // Enable gzip compression
+  // ref: https://www.apollographql.com/docs/engine/setup-node.html#enabling-compression
+  // server.express.use(compression())
 
-server.start({
-  tracing: true,
-  cacheControl: true
-}, () => console.log('Server is running on localhost:4000'))
+  const httpServer = await server.configure({
+    tracing: true,
+    cacheControl: true
+  });
+
+  engine.listen(
+    {
+      port,
+      httpServer,
+      graphqlPaths: ["/"]
+    },
+    () =>
+      console.log(`Server is running on http://localhost:${port} (with engine)`)
+  );
+
+  server.createSubscriptionServer(httpServer);
+};
+
+start();

--- a/examples/apollo-engine/index.js
+++ b/examples/apollo-engine/index.js
@@ -40,7 +40,7 @@ const resolvers = {
 
 const pubsub = new PubSub();
 const port = parseInt(process.env.PORT, 10) || 4000;
-const server = new GraphQLServer({
+const graphQLServer = new GraphQLServer({
   typeDefs,
   resolvers,
   context: { pubsub }
@@ -50,7 +50,7 @@ const engine = new ApolloEngine({
   apiKey: process.env.APOLLO_ENGINE_KEY
 });
 
-const httpServer = server.configure({
+const httpServer = graphQLServer.createHttpServer({
   tracing: true,
   cacheControl: true
 });
@@ -65,4 +65,4 @@ engine.listen(
     console.log(`Server is running on http://localhost:${port}`)
 );
 
-server.createSubscriptionServer(httpServer);
+graphQLServer.createSubscriptionServer(httpServer);

--- a/examples/apollo-engine/index.js
+++ b/examples/apollo-engine/index.js
@@ -38,35 +38,31 @@ const resolvers = {
   }
 };
 
-const start = async () => {
-  const pubsub = new PubSub();
-  const port = parseInt(process.env.PORT, 10) || 4000;
-  const server = new GraphQLServer({
-    typeDefs,
-    resolvers,
-    context: { pubsub }
-  });
+const pubsub = new PubSub();
+const port = parseInt(process.env.PORT, 10) || 4000;
+const server = new GraphQLServer({
+  typeDefs,
+  resolvers,
+  context: { pubsub }
+});
 
-  const engine = new ApolloEngine({
-    apiKey: process.env.APOLLO_ENGINE_KEY
-  });
+const engine = new ApolloEngine({
+  apiKey: process.env.APOLLO_ENGINE_KEY
+});
 
-  const httpServer = await server.configure({
-    tracing: true,
-    cacheControl: true
-  });
+const httpServer = server.configure({
+  tracing: true,
+  cacheControl: true
+});
 
-  engine.listen(
-    {
-      port,
-      httpServer,
-      graphqlPaths: ["/"]
-    },
-    () =>
-      console.log(`Server is running on http://localhost:${port} (with engine)`)
-  );
+engine.listen(
+  {
+    port,
+    httpServer,
+    graphqlPaths: ["/"]
+  },
+  () =>
+    console.log(`Server is running on http://localhost:${port}`)
+);
 
-  server.createSubscriptionServer(httpServer);
-};
-
-start();
+server.createSubscriptionServer(httpServer);

--- a/examples/apollo-engine/package.json
+++ b/examples/apollo-engine/package.json
@@ -3,7 +3,7 @@
     "start": "node ."
   },
   "dependencies": {
-    "apollo-engine": "0.8.5",
+    "apollo-engine": "^1.0.1",
     "compression": "1.7.1",
     "graphql-yoga": "1.2.0"
   }

--- a/examples/apollo-engine/package.json
+++ b/examples/apollo-engine/package.json
@@ -4,7 +4,6 @@
   },
   "dependencies": {
     "apollo-engine": "^1.0.1",
-    "compression": "1.7.1",
     "graphql-yoga": "1.2.0"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,12 +28,12 @@ import * as path from 'path'
 import customFieldResolver from './customFieldResolver'
 import { SubscriptionServer } from 'subscriptions-transport-ws'
 
-import { SubscriptionServerOptions, Options, Props } from './types'
+import { SubscriptionServerOptions, Options, OptionsWithHttps, OptionsWithoutHttps, Props } from './types'
 import { ITypeDefinitions } from 'graphql-tools/dist/Interfaces'
 import { defaultErrorFormatter } from './defaultErrorFormatter'
 
 export { PubSub, withFilter } from 'graphql-subscriptions'
-export { Options }
+export { Options, OptionsWithHttps, OptionsWithoutHttps }
 export { GraphQLServerLambda } from './lambda'
 
 // TODO remove once `@types/graphql` is fixed for `execute`
@@ -131,6 +131,8 @@ export class GraphQLServer {
     return this
   }
 
+  createHttpServer(options: OptionsWithoutHttps): HttpServer
+  createHttpServer(options: OptionsWithHttps): HttpsServer
   createHttpServer(options: Options): HttpServer | HttpsServer {
     const app = this.express
 
@@ -241,7 +243,7 @@ export class GraphQLServer {
       throw new Error('No schema defined')
     }
 
-    const server: HttpServer | HttpsServer = this.options.https
+    const server = this.options.https
       ? createHttpsServer(this.options.https, app)
       : createServer(app)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,7 @@ type ExecuteFunction = (
 export class GraphQLServer {
   express: express.Application
   subscriptionServer: SubscriptionServer | null
+  subscriptionServerOptions: SubscriptionServerOptions | null = null
   options: Options = {
     tracing: { mode: 'http-header' },
     port: process.env.PORT || 4000,
@@ -130,32 +131,15 @@ export class GraphQLServer {
     return this
   }
 
-  start(
+  configure(
     options: Options,
-    callback?: ((options: Options) => void),
-  ): Promise<Server | HttpsServer>
-  start(callback?: ((options: Options) => void)): Promise<Server | HttpsServer>
-  start(
-    optionsOrCallback?: Options | ((options: Options) => void),
-    callback?: ((options: Options) => void),
-  ): Promise<Server | HttpsServer> {
-    const options =
-      optionsOrCallback && typeof optionsOrCallback === 'function'
-        ? {}
-        : optionsOrCallback
-    const callbackFunc = callback
-      ? callback
-      : optionsOrCallback && typeof optionsOrCallback === 'function'
-        ? optionsOrCallback
-        : () => null
-
+  ): Server | HttpsServer {
     const app = this.express
 
     this.options = { ...this.options, ...options }
 
-    let subscriptionServerOptions: SubscriptionServerOptions | null = null
     if (this.options.subscriptions) {
-      subscriptionServerOptions =
+      this.subscriptionServerOptions =
         typeof this.options.subscriptions === 'string'
           ? { path: this.options.subscriptions }
           : { path: '/', ...this.options.subscriptions }
@@ -245,11 +229,11 @@ export class GraphQLServer {
     )
 
     if (this.options.playground) {
-      const playgroundOptions = subscriptionServerOptions
+      const playgroundOptions = this.subscriptionServerOptions
         ? {
-            endpoint: this.options.endpoint,
-            subscriptionsEndpoint: subscriptionServerOptions.path,
-          }
+          endpoint: this.options.endpoint,
+          subscriptionsEndpoint: this.subscriptionServerOptions.path,
+        }
         : { endpoint: this.options.endpoint }
 
       app.get(this.options.playground, expressPlayground(playgroundOptions))
@@ -259,69 +243,85 @@ export class GraphQLServer {
       throw new Error('No schema defined')
     }
 
+    const server: Server | HttpsServer = this.options.https ?
+      createHttpsServer(this.options.https, app) : createServer(app);
+
+    return server
+  }
+
+  start(
+    options: Options,
+    callback?: ((options: Options) => void),
+  ): Promise<Server | HttpsServer>
+  start(callback?: ((options: Options) => void)): Promise<Server | HttpsServer>
+  start(
+    optionsOrCallback?: Options | ((options: Options) => void),
+    callback?: ((options: Options) => void),
+  ): Promise<Server | HttpsServer> {
+    const options =
+      optionsOrCallback && typeof optionsOrCallback === 'function'
+        ? {}
+        : optionsOrCallback
+    const callbackFunc = callback
+      ? callback
+      : optionsOrCallback && typeof optionsOrCallback === 'function'
+        ? optionsOrCallback
+        : () => null
+
+    const server = this.configure(options as Options)
+
     return new Promise((resolve, reject) => {
-      const server: Server | HttpsServer = this.options.https
-        ? createHttpsServer(this.options.https, app)
-        : createServer(app)
+      const combinedServer = server;
+      combinedServer.listen(this.options.port, () => {
+        callbackFunc(this.options)
+        resolve(combinedServer)
+      })
 
-      if (!subscriptionServerOptions) {
-        server.listen(this.options.port, () => {
-          callbackFunc(this.options)
-          resolve(server)
-        })
-      } else {
-        const combinedServer = server
-        combinedServer.listen(this.options.port, () => {
-          callbackFunc(this.options)
-          resolve(combinedServer)
-        })
-
-        this.subscriptionServer = SubscriptionServer.create(
-          {
-            schema: this.executableSchema,
-            // TODO remove once `@types/graphql` is fixed for `execute`
-            execute: execute as ExecuteFunction,
-            subscribe,
-            onConnect: subscriptionServerOptions.onConnect
-              ? subscriptionServerOptions.onConnect
-              : async (connectionParams, webSocket) => ({
-                  ...connectionParams,
-                }),
-            onDisconnect: subscriptionServerOptions.onDisconnect,
-            onOperation: async (message, connection, webSocket) => {
-              // The following should be replaced when SubscriptionServer accepts a formatError
-              // parameter for custom error formatting.
-              // See https://github.com/apollographql/subscriptions-transport-ws/issues/182
-              connection.formatResponse = value => ({
-                ...value,
-                errors:
-                  value.errors &&
-                  value.errors.map(
-                    this.options.formatError || defaultErrorFormatter,
-                  ),
-              })
-
-              let context
-              try {
-                context =
-                  typeof this.context === 'function'
-                    ? await this.context({ connection })
-                    : this.context
-              } catch (e) {
-                console.error(e)
-                throw e
-              }
-              return { ...connection, context }
-            },
-            keepAlive: subscriptionServerOptions.keepAlive,
-          },
-          {
-            server: combinedServer,
-            path: subscriptionServerOptions.path,
-          },
-        )
+      if (this.subscriptionServerOptions) {
+        this.createSubscriptionServer(combinedServer);
       }
     })
+  }
+
+  createSubscriptionServer(combinedServer: Server | HttpsServer ) {
+    this.subscriptionServer = SubscriptionServer.create(
+      {
+        schema: this.executableSchema,
+        // TODO remove once `@types/graphql` is fixed for `execute`
+        execute: execute as ExecuteFunction,
+        subscribe,
+        onConnect: this.subscriptionServerOptions.onConnect
+          ? this.subscriptionServerOptions.onConnect
+          : async (connectionParams, webSocket) => ({ ...connectionParams }),
+        onDisconnect: this.subscriptionServerOptions.onDisconnect,
+        onOperation: async (message, connection, webSocket) => {
+          // The following should be replaced when SubscriptionServer accepts a formatError
+          // parameter for custom error formatting.
+          // See https://github.com/apollographql/subscriptions-transport-ws/issues/182
+          connection.formatResponse = value => ({
+            ...value,
+            errors: value.errors && value.errors.map(this.options.formatError || defaultErrorFormatter),
+          })
+
+          let context
+          try {
+            context =
+              typeof this.context === 'function'
+                ? await this.context({ connection })
+                : this.context
+          } catch (e) {
+            console.error(e)
+            throw e
+          }
+          return { ...connection, context }
+        },
+        keepAlive: this.subscriptionServerOptions.keepAlive,
+      },
+      {
+        server: combinedServer,
+        path: this.subscriptionServerOptions.path,
+      },
+    )
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -131,7 +131,7 @@ export class GraphQLServer {
     return this
   }
 
-  configure(options: Options): HttpServer | HttpsServer {
+  createHttpServer(options: Options): HttpServer | HttpsServer {
     const app = this.express
 
     this.options = { ...this.options, ...options }
@@ -267,7 +267,7 @@ export class GraphQLServer {
         ? optionsOrCallback
         : () => null
 
-    const server = this.configure(options as Options)
+    const server = this.createHttpServer(options as Options)
 
     return new Promise((resolve, reject) => {
       const combinedServer = server

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ import { importSchema } from 'graphql-import'
 import expressPlayground from 'graphql-playground-middleware-express'
 import { makeExecutableSchema } from 'graphql-tools'
 import { applyMiddleware as applyFieldMiddleware } from 'graphql-middleware'
-import { createServer, Server } from 'http'
+import { createServer, Server as HttpServer } from 'http'
 import { createServer as createHttpsServer, Server as HttpsServer } from 'https'
 import * as path from 'path'
 import customFieldResolver from './customFieldResolver'
@@ -131,7 +131,7 @@ export class GraphQLServer {
     return this
   }
 
-  configure(options: Options): Server | HttpsServer {
+  configure(options: Options): HttpServer | HttpsServer {
     const app = this.express
 
     this.options = { ...this.options, ...options }
@@ -241,7 +241,7 @@ export class GraphQLServer {
       throw new Error('No schema defined')
     }
 
-    const server: Server | HttpsServer = this.options.https
+    const server: HttpServer | HttpsServer = this.options.https
       ? createHttpsServer(this.options.https, app)
       : createServer(app)
 
@@ -251,12 +251,12 @@ export class GraphQLServer {
   start(
     options: Options,
     callback?: ((options: Options) => void),
-  ): Promise<Server | HttpsServer>
-  start(callback?: ((options: Options) => void)): Promise<Server | HttpsServer>
+  ): Promise<HttpServer | HttpsServer>
+  start(callback?: ((options: Options) => void)): Promise<HttpServer | HttpsServer>
   start(
     optionsOrCallback?: Options | ((options: Options) => void),
     callback?: ((options: Options) => void),
-  ): Promise<Server | HttpsServer> {
+  ): Promise<HttpServer | HttpsServer> {
     const options =
       optionsOrCallback && typeof optionsOrCallback === 'function'
         ? {}
@@ -282,7 +282,7 @@ export class GraphQLServer {
     })
   }
 
-  createSubscriptionServer(combinedServer: Server | HttpsServer) {
+  createSubscriptionServer(combinedServer: HttpServer | HttpsServer) {
     this.subscriptionServer = SubscriptionServer.create(
       {
         schema: this.executableSchema,

--- a/src/index.ts
+++ b/src/index.ts
@@ -245,6 +245,10 @@ export class GraphQLServer {
       ? createHttpsServer(this.options.https, app)
       : createServer(app)
 
+    if (this.subscriptionServerOptions) {
+      this.createSubscriptionServer(server)
+    }
+
     return server
   }
 
@@ -275,14 +279,10 @@ export class GraphQLServer {
         callbackFunc(this.options)
         resolve(combinedServer)
       })
-
-      if (this.subscriptionServerOptions) {
-        this.createSubscriptionServer(combinedServer)
-      }
     })
   }
 
-  createSubscriptionServer(combinedServer: HttpServer | HttpsServer) {
+  private createSubscriptionServer(combinedServer: HttpServer | HttpsServer) {
     this.subscriptionServer = SubscriptionServer.create(
       {
         schema: this.executableSchema,

--- a/src/index.ts
+++ b/src/index.ts
@@ -131,9 +131,7 @@ export class GraphQLServer {
     return this
   }
 
-  configure(
-    options: Options,
-  ): Server | HttpsServer {
+  configure(options: Options): Server | HttpsServer {
     const app = this.express
 
     this.options = { ...this.options, ...options }
@@ -231,9 +229,9 @@ export class GraphQLServer {
     if (this.options.playground) {
       const playgroundOptions = this.subscriptionServerOptions
         ? {
-          endpoint: this.options.endpoint,
-          subscriptionsEndpoint: this.subscriptionServerOptions.path,
-        }
+            endpoint: this.options.endpoint,
+            subscriptionsEndpoint: this.subscriptionServerOptions.path,
+          }
         : { endpoint: this.options.endpoint }
 
       app.get(this.options.playground, expressPlayground(playgroundOptions))
@@ -243,8 +241,9 @@ export class GraphQLServer {
       throw new Error('No schema defined')
     }
 
-    const server: Server | HttpsServer = this.options.https ?
-      createHttpsServer(this.options.https, app) : createServer(app);
+    const server: Server | HttpsServer = this.options.https
+      ? createHttpsServer(this.options.https, app)
+      : createServer(app)
 
     return server
   }
@@ -271,19 +270,19 @@ export class GraphQLServer {
     const server = this.configure(options as Options)
 
     return new Promise((resolve, reject) => {
-      const combinedServer = server;
+      const combinedServer = server
       combinedServer.listen(this.options.port, () => {
         callbackFunc(this.options)
         resolve(combinedServer)
       })
 
       if (this.subscriptionServerOptions) {
-        this.createSubscriptionServer(combinedServer);
+        this.createSubscriptionServer(combinedServer)
       }
     })
   }
 
-  createSubscriptionServer(combinedServer: Server | HttpsServer ) {
+  createSubscriptionServer(combinedServer: Server | HttpsServer) {
     this.subscriptionServer = SubscriptionServer.create(
       {
         schema: this.executableSchema,
@@ -300,7 +299,11 @@ export class GraphQLServer {
           // See https://github.com/apollographql/subscriptions-transport-ws/issues/182
           connection.formatResponse = value => ({
             ...value,
-            errors: value.errors && value.errors.map(this.options.formatError || defaultErrorFormatter),
+            errors:
+              value.errors &&
+              value.errors.map(
+                this.options.formatError || defaultErrorFormatter,
+              ),
           })
 
           let context

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,7 @@ import { ExecutionParams } from 'subscriptions-transport-ws'
 import { LogFunction } from 'apollo-server-core'
 import { IMiddleware as IFieldMiddleware } from 'graphql-middleware'
 
+export type Omit<T, K> = Pick<T, Exclude<keyof T, K>>
 export interface IResolvers {
   [key: string]: (() => any) | IResolverObject | GraphQLScalarType
 }
@@ -79,6 +80,12 @@ export interface Options extends ApolloServerOptions {
   playground?: string | false
   https?: HttpsOptions
 }
+
+export interface OptionsWithHttps extends Options {
+  https: HttpsOptions
+}
+
+export type OptionsWithoutHttps = Omit<Options, "https">
 
 export interface SubscriptionServerOptions {
   path?: string


### PR DESCRIPTION
Related: #206 

Just for sharing and discussing.

TODO:
- [x] Split `start` in two functions to avoid this `server.start({autoStart: false})` pattern
- [x] Understand and fix why the subscriptions are not working with apollo-engine

BTW, it can be nice to add a prettier in this project, my VSCode reformat everything without my permission…

Please note that you need to `npm link` or `yarn link` with the local version of `graphql-yoga` to try 😉 (it can be obvious, but just in case ^^)