### PR TITLE
fix(deps): Updates graphql-yoga dependency to 1.6.0. Otherwise the ex…

### DIFF
--- a/examples/custom-directives/package.json
+++ b/examples/custom-directives/package.json
@@ -3,6 +3,6 @@
     "start": "node ."
   },
   "dependencies": {
-    "graphql-yoga": "1.2.0"
+    "graphql-yoga": "1.6.0"
   }
 }


### PR DESCRIPTION
…ample does not work - the directive resolvers are not invoked.