### PR TITLE
Use an alias aware field resolver as a default

### DIFF
--- a/src/customFieldResolver.ts
+++ b/src/customFieldResolver.ts
@@ -1,0 +1,18 @@
+const customFieldResolver = (source, args, context, info) => {
+  // ensure source is a value for which property access is acceptable.
+  if (typeof source === "object" || typeof source === "function") {
+    const property =
+      source[
+        info.fieldNodes[0].alias
+          ? info.fieldNodes[0].alias.value
+          : info.fieldName
+      ];
+    if (typeof property === "function") {
+      return source[info.fieldName](args, context, info);
+    }
+    return property;
+  }
+};
+
+export default customFieldResolver;
+export { customFieldResolver };

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import { makeExecutableSchema } from 'graphql-tools'
 import { createServer, Server } from 'http'
 import { createServer as createHttpsServer, Server as HttpsServer} from 'https';
 import * as path from 'path'
+import customFieldResolver from './customFieldResolver'
 import { SubscriptionServer } from 'subscriptions-transport-ws'
 
 import { SubscriptionServerOptions, Options, Props } from './types'
@@ -199,7 +200,7 @@ export class GraphQLServer {
           logFunction: this.options.logFunction,
           rootValue: this.options.rootValue,
           validationRules: this.options.validationRules,
-          fieldResolver: this.options.fieldResolver,
+          fieldResolver: this.options.fieldResolver || customFieldResolver,
           formatParams: this.options.formatParams,
           formatResponse: this.options.formatResponse,
           debug: this.options.debug,

--- a/src/lambda.ts
+++ b/src/lambda.ts
@@ -5,6 +5,7 @@ import { importSchema } from 'graphql-import'
 import lambdaPlayground from 'graphql-playground-middleware-lambda'
 import { makeExecutableSchema } from 'graphql-tools'
 import * as path from 'path'
+import customFieldResolver from './customFieldResolver'
 
 import { LambdaOptions, LambdaProps } from './types'
 
@@ -92,7 +93,7 @@ export class GraphQLServerLambda {
         logFunction: this.options.logFunction,
         rootValue: this.options.rootValue,
         validationRules: this.options.validationRules,
-        fieldResolver: this.options.fieldResolver,
+        fieldResolver: this.options.fieldResolver || customFieldResolver,
         formatParams: this.options.formatParams,
         formatResponse: this.options.formatResponse,
         debug: this.options.debug,


### PR DESCRIPTION
Use an alias aware field resolver as a default if a custom resolver is not supplied. This is required to get around https://github.com/graphcool/prisma/issues/1896

Please let me know if any changes are needed. 