### PR TITLE
Adding possibility for multiple files in typedefs

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ The `props` argument accepts the following fields:
 
 | Key | Type | Default | Note |
 | ---  | --- | --- | --- |
-| `typeDefs` | String  |  `null` | Contains GraphQL type definitions in [SDL](https://blog.graph.cool/graphql-sdl-schema-definition-language-6755bcb9ce51) or file path to type definitions (required if `schema` is not provided \*)  |
+| `typeDefs` | `String` or `Function` or `DocumentNode` or `array` of previous |  `null` | Contains GraphQL type definitions in [SDL](https://blog.graph.cool/graphql-sdl-schema-definition-language-6755bcb9ce51) or file path to type definitions (required if `schema` is not provided \*)  |
 | `resolvers`  | Object  |  `null`  | Contains resolvers for the fields specified in `typeDefs` (required if `schema` is not provided \*) |
 | `schema`  | Object |  `null`  | An instance of [`GraphQLSchema`](http://graphql.org/graphql-js/type/#graphqlschema) (required if `typeDefs` and `resolvers` are not provided \*) |
 | `context`  | Object or Function  |  `{}`  | Contains custom data being passed through your resolver chain. This can be passed in as an object, or as a Function with the signature `(req: ContextParameters) => any` \*\* |

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,7 +57,7 @@ export class GraphQLServer {
     } else if (props.typeDefs && props.resolvers) {
       const { directiveResolvers, resolvers, typeDefs } = props
 
-      const typeDefsString = buildTypeDefsString(typeDefs)
+      const typeDefsString = mergeTypeDefs(typeDefs)
 
       const uploadMixin = typeDefsString.includes('scalar Upload')
         ? { Upload: GraphQLUpload }
@@ -281,26 +281,19 @@ export class GraphQLServer {
   }
 }
 
-function buildTypeDefsString(typeDefs: ITypeDefinitions): string {
-  let typeDefinitions = mergeTypeDefs(typeDefs)
-
-  // read from .graphql file if path provided
-  if (typeDefinitions.endsWith('graphql')) {
-    const schemaPath = path.resolve(typeDefinitions)
-
-    if (!fs.existsSync(schemaPath)) {
-      throw new Error(`No schema found for path: ${schemaPath}`)
-    }
-
-    typeDefinitions = importSchema(schemaPath)
-  }
-
-  return typeDefinitions
-}
-
 function mergeTypeDefs(typeDefs: ITypeDefinitions): string {
   if (typeof typeDefs === 'string') {
-    return typeDefs
+    if (typeDefs.endsWith('graphql')) {
+      const schemaPath = path.resolve(typeDefs)
+  
+      if (!fs.existsSync(schemaPath)) {
+        throw new Error(`No schema found for path: ${schemaPath}`)
+      }
+  
+      return importSchema(schemaPath)
+    } else {
+      return typeDefs
+    }
   }
 
   if (typeof typeDefs === 'function') {

--- a/src/index.ts
+++ b/src/index.ts
@@ -304,7 +304,11 @@ function mergeTypeDefs(typeDefs: ITypeDefinitions): string {
     return print(typeDefs)
   }
 
-  return typeDefs.reduce<string>((acc, t) => acc + '\n' + mergeTypeDefs(t), '')
+  if (Array.isArray(typeDefs)) {
+    return typeDefs.reduce<string>((acc, t) => acc + '\n' + mergeTypeDefs(t), '')
+  }
+
+  throw new Error('Typedef is not string, function, DocumentNode or array of previous')
 }
 
 function isDocumentNode(node: any): node is DocumentNode {


### PR DESCRIPTION
Adding possibility for multiple files in `typedefs` fixes #205. Documentation needs to be updated, because its missing support for arrays in general :) 