### PR TITLE
docs(readme): Mention port can be a string

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ The `options` object has the following fields:
 | ---  | --- | --- | --- |
 | `cors` | Object |  `null` | Contains [configuration options](https://github.com/expressjs/cors#configuration-options) for [cors](https://github.com/expressjs/cors) |
 | `tracing`  | Boolean or [TracingOptions](/src/types.ts#L49-L51)  |  `'http-header'`  | Indicates whether [Apollo Tracing](https://github.com/apollographql/apollo-tracing) should be enabled or disabled for your server (if a string is provided, accepted values are: `'enabled'`, `'disabled'`, `'http-header'`) |
-| `port`  | Number |  `4000`  | Determines the port your server will be listening on (note that you can also specify the port by setting the `PORT` environment variable) |
+| `port`  | Number or String |  `4000`  | Determines the port your server will be listening on (note that you can also specify the port by setting the `PORT` environment variable) |
 | `endpoint`  | String  |  `'/'`  | Defines the HTTP endpoint of your server |
 | `subscriptions` | Object or String or `false`  |  `'/'`  | Defines the subscriptions (websocket) endpoint for your server; accepts an object with [subscription server options](https://github.com/apollographql/subscriptions-transport-ws#constructoroptions-socketoptions) `path`, `keepAlive`, `onConnect` and `onDisconnect`; setting to `false` disables subscriptions completely |
 | `playground` | String or `false` |  `'/'`  | Defines the endpoint where you can invoke the [Playground](https://github.com/graphcool/graphql-playground); setting to `false` disables the playground endpoint |


### PR DESCRIPTION
I mistakenly didn't include this on PR #237.