### PR TITLE
Add Response to context as well.

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ The `props` argument accepts the following fields:
 > 1. Provide `typeDefs` and `resolvers` and omit the `schema`, in this case `graphql-yoga` will construct the `GraphQLSchema` instance using [`makeExecutableSchema`](https://www.apollographql.com/docs/graphql-tools/generate-schema.html#makeExecutableSchema) from [`graphql-tools`](https://github.com/apollographql/graphql-tools).
 > 2. Provide the `schema` directly and omit `typeDefs` and `resolvers`.
 
-> (\*\*) Notice that the `req` argument is an object of the shape `{ request, connection }` which either carries a `request: Request` property (when it's a `Query`/`Mutation` resolver) or a `connection: SubscriptionOptions` property (when it's a `Subscription` resolver). [`Request`](http://expressjs.com/en/api.html#req) is imported from Express.js. `SubscriptionOptions` is from the [`graphql-subscriptions`](https://github.com/apollographql/graphql-subscriptions) package. `SubscriptionOptions` are getting the `connectionParams` automatically injected under `SubscriptionOptions.context.[CONNECTION_PARAMETER_NAME]`
+> (\*\*) Notice that the `req` argument is an object of the shape `{ request, response, connection }` which either carries a `request: Request` property (when it's a `Query`/`Mutation` resolver), `response: Response` property (when it's a `Query`/`Mutation` resolver), or a `connection: SubscriptionOptions` property (when it's a `Subscription` resolver). [`Request`](http://expressjs.com/en/api.html#req) is imported from Express.js. [`Response`](http://expressjs.com/en/api.html#res) is imported from Express.js aswell. `SubscriptionOptions` is from the [`graphql-subscriptions`](https://github.com/apollographql/graphql-subscriptions) package. `SubscriptionOptions` are getting the `connectionParams` automatically injected under `SubscriptionOptions.context.[CONNECTION_PARAMETER_NAME]`
+
 
 Here is example of creating a new server:
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -191,7 +191,7 @@ export class GraphQLServer {
         try {
           context =
             typeof this.context === 'function'
-              ? await this.context({ request }, { response })
+              ? await this.context({ request, response })
               : this.context
         } catch (e) {
           console.error(e)

--- a/src/index.ts
+++ b/src/index.ts
@@ -186,12 +186,12 @@ export class GraphQLServer {
 
     app.post(
       this.options.endpoint,
-      graphqlExpress(async request => {
+      graphqlExpress(async (request, response) => {
         let context
         try {
           context =
             typeof this.context === 'function'
-              ? await this.context({ request })
+              ? await this.context({ request }, { response })
               : this.context
         } catch (e) {
           console.error(e)


### PR DESCRIPTION
## Passing Response to Context.

This pull request passes the express response object as a parameter to the context when it is a function.

### Possible Use Cases:

1. Setting up cookie.
2. Sending a custom response.
3. Authentication and Session Management.
