### PR TITLE
Add `Options.listen`

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ The `options` object has the following fields:
 | `playground` | String or `false` |  `'/'`  | Defines the endpoint where you can invoke the [Playground](https://github.com/graphcool/graphql-playground); setting to `false` disables the playground endpoint |
 | `uploads` | [UploadOptions](/src/types.ts#L39-L43) or `false` or `undefined`  | `null`  | Provides information about upload limits; the object can have any combination of the following three keys: `maxFieldSize`, `maxFileSize`, `maxFiles`; each of these have values of type Number; setting to `false` disables file uploading |
 | `https` | [HttpsOptions](/src/types.ts#L62-L65) or `undefined` | `undefined` | Enables HTTPS support with a key/cert |
+| `listen` | [boolean](/src/types.ts#L62-L65) or `undefined` | `true` | Whether or not to start listening on `port` when calling `start()` |
 
 Additionally, the `options` object exposes these `apollo-server` options:
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,6 +57,7 @@ export class GraphQLServer {
     endpoint: '/',
     subscriptions: '/',
     playground: '/',
+    listen: true,
   }
   executableSchema: GraphQLSchema
   context: any
@@ -249,6 +250,11 @@ export class GraphQLServer {
 
     if (!this.executableSchema) {
       throw new Error('No schema defined')
+    }
+
+    if (!this.options.listen) {
+      callbackFunc(this.options)
+      return Promise.resolve(null)
     }
 
     return new Promise((resolve, reject) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -77,6 +77,7 @@ export interface Options extends ApolloServerOptions {
   subscriptions?: SubscriptionServerOptions | string | false
   playground?: string | false
   https?: HttpsOptions
+  listen: boolean
 }
 
 export interface SubscriptionServerOptions {


### PR DESCRIPTION
PR adds an option to start the server without listening to a port.

Enables easier integration tests. If I have several integration tests in parallel starting -- if each `start()` listens to a port, the ports will collide.

The changes in this PR enable me to use [supertest](https://github.com/visionmedia/supertest) to do integration testing of my API.

Example:

```js
const server = new GraphQLServer({ /* ... */ });

await server.start({listen: false});

// ...

const { body } = await supertest(server.express)
  .post('/')
  .send(requestBody)
  .set('Authorization', `Bearer ${token}`)
  .set('Accept', 'application/json');

expect(body).not.toHaveProperty('errors');
expect(body.data)//.....
```