### PR TITLE
Add GET endpoint option

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ The `options` object has the following fields:
 | `playground` | String or `false` |  `'/'`  | Defines the endpoint where you can invoke the [Playground](https://github.com/graphcool/graphql-playground); setting to `false` disables the playground endpoint |
 | `uploads` | [UploadOptions](/src/types.ts#L39-L43) or `false` or `undefined`  | `null`  | Provides information about upload limits; the object can have any combination of the following three keys: `maxFieldSize`, `maxFileSize`, `maxFiles`; each of these have values of type Number; setting to `false` disables file uploading |
 | `https` | [HttpsOptions](/src/types.ts#L62-L65) or `undefined` | `undefined` | Enables HTTPS support with a key/cert |
+| `getEndpoint`  | String or Boolean |  `null`  | Adds a graphql HTTP GET endpoint to your server (defaults to `endpoint` if `true`).  Used for leveraging CDN level caching. |
 
 Additionally, the `options` object exposes these `apollo-server` options:
 
@@ -228,4 +229,3 @@ Any middlewares you add to that route, will be added right before the `apollo-se
 Join our [Slack community](http://slack.graph.cool/) if you run into issues or have questions. We love talking to you!
 
 [![](http://i.imgur.com/5RHR6Ku.png)](https://www.graph.cool/)
-

--- a/src/index.ts
+++ b/src/index.ts
@@ -235,6 +235,40 @@ export class GraphQLServer {
         }
       }),
     )
+    
+    // Only add GET endpoint if opted in
+    if (this.options.getEndpoint) {
+      app.get(
+        this.options.getEndpoint === true ? this.options.endpoint : this.options.getEndpoint,
+        graphqlExpress(async (request, response) => {
+          let context
+          try {
+            context =
+              typeof this.context === 'function'
+                ? await this.context({ request, response })
+                : this.context
+          } catch (e) {
+            console.error(e)
+            throw e
+          }
+
+          return {
+            schema: this.executableSchema,
+            tracing: tracing(request),
+            cacheControl: this.options.cacheControl,
+            formatError: this.options.formatError || defaultErrorFormatter,
+            logFunction: this.options.logFunction,
+            rootValue: this.options.rootValue,
+            validationRules: this.options.validationRules,
+            fieldResolver: this.options.fieldResolver || customFieldResolver,
+            formatParams: this.options.formatParams,
+            formatResponse: this.options.formatResponse,
+            debug: this.options.debug,
+            context,
+          }
+        }),
+      )
+    }
 
     if (this.options.playground) {
       const playgroundOptions = subscriptionServerOptions


### PR DESCRIPTION
One of the powers of persisted queries is that you can leverage CDN's to offload caching.

It's a opt in obviously, since it's for user's who understand the dangers and complexities of introducing such a optimization (settings appropriate cache-control headers, ensuring query being used only contains data that can *fully* be cached, ect).