### PR TITLE
`validationRules` as callback + query complexity example

### DIFF
--- a/examples/query-complexity/README.md
+++ b/examples/query-complexity/README.md
@@ -1,0 +1,84 @@
+# GraphQL Query Complexity / Cost analysis
+
+This directory contains an example with query complexity analysis based on `graphql-yoga` and [`graphql-cost-analysis`](https://github.com/pa-bru/graphql-cost-analysis).
+
+## Get started
+
+**Clone the repository:**
+
+```sh
+git clone https://github.com/graphcool/graphql-yoga.git
+cd graphql-yoga/examples/query-complexity
+```
+
+**Install dependencies and run the app:**
+
+```sh
+yarn install # or npm install
+yarn start   # or npm start
+```
+
+## Testing
+
+Open your browser at [http://localhost:4000](http://localhost:4000) and start sending queries.
+
+### Simple query
+
+```graphql
+{
+  posts(limit:1) {
+    id
+    title
+  }
+}
+```
+
+#### `200` Response
+
+```json
+{
+  "data": {
+    "posts": [
+      {
+        "id": 0,
+        "title": "My first blog post"
+      }
+    ]
+  }
+}
+```
+
+### Too complex query
+
+```graphql
+{
+  posts(limit:5) {
+    id
+    title
+  }
+}
+```
+
+#### `400` response:
+
+```json
+{
+  "errors": [
+    {
+      "message": "The query exceeds the maximum cost of 50. Actual cost is 52"
+    }
+  ]
+}
+```
+
+## Implementation
+
+The query complexity is calculated with the help of the `@cost`-directive defined in [`index.js`](./index.js).
+
+## Further reading
+
+
+- [`graphql-cost-analysis` Documentation](https://github.com/pa-bru/graphql-cost-analysis)
+- [How to GraphQL: Security and GraphQL Tutorial](https://www.howtographql.com/advanced/4-security/)
+- [Apollo: Securing Your GraphQL API from Malicious Queries
+](https://dev-blog.apollodata.com/securing-your-graphql-api-from-malicious-queries-16130a324a6b)

--- a/examples/query-complexity/index.js
+++ b/examples/query-complexity/index.js
@@ -1,0 +1,60 @@
+const { GraphQLServer } = require('../../dist/src/index')
+const { default: costAnalysis } = require('graphql-cost-analysis')
+
+const typeDefs = `
+  type Query {
+    posts(limit: Int!): [Post!]! 
+      @cost(multipliers: ["limit"], complexity: 10)
+  }
+
+  type Post {
+    id: Int!
+    title: String!
+  }
+
+  directive @cost(
+    complexity: Int
+    useMultipliers: Boolean
+    multipliers: [String!]
+  ) on FIELD_DEFINITION
+`
+
+const posts = [
+  'My first blog post', 
+  'My second', 
+  'My third', 
+  'My fourth',
+  'My fifth',
+].map((title, index) => ({
+  id: index,
+  title,
+}))
+
+const resolvers = {
+  Query: {
+    posts: (source, {limit}) => posts.slice(0, limit),
+  },
+}
+
+const server = new GraphQLServer({ 
+  typeDefs, 
+  resolvers,
+})
+
+server.start({
+  validationRules: (req) => [
+    costAnalysis({
+      variables: req.query.variables,
+      maximumCost: 50,
+      defaultCost: 1,
+      onComplete(cost) {
+        console.log(`Cost analysis score: ${cost}`)
+      },
+    })
+  ]
+}).then(() => {
+  console.log('Server is running on http://localhost:4000')
+}).catch(() => {
+  console.error('Server start failed', err)
+  process.exit(1)
+})

--- a/examples/query-complexity/package.json
+++ b/examples/query-complexity/package.json
@@ -1,0 +1,8 @@
+{
+  "scripts": {
+    "start": "node ."
+  },
+  "dependencies": {
+    "graphql-cost-analysis": "^1.0.1"
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -234,7 +234,10 @@ export class GraphQLServer {
           formatError: this.options.formatError || defaultErrorFormatter,
           logFunction: this.options.logFunction,
           rootValue: this.options.rootValue,
-          validationRules: this.options.validationRules,
+          validationRules:
+            typeof this.options.validationRules === 'function'
+              ? this.options.validationRules(request, response)
+              : this.options.validationRules,
           fieldResolver: this.options.fieldResolver || customFieldResolver,
           formatParams: this.options.formatParams,
           formatResponse: this.options.formatResponse,

--- a/src/lambda.ts
+++ b/src/lambda.ts
@@ -7,7 +7,7 @@ import { makeExecutableSchema } from 'graphql-tools'
 import * as path from 'path'
 import customFieldResolver from './customFieldResolver'
 
-import { LambdaOptions, LambdaProps } from './types'
+import { LambdaOptions, LambdaProps, ValidationRules } from './types'
 
 export class GraphQLServerLambda {
   options: LambdaOptions
@@ -85,6 +85,12 @@ export class GraphQLServerLambda {
         throw e
       }
 
+      if (typeof this.options.validationRules === 'function') {
+        throw new Error(
+          'validationRules as callback is only compatible with Express',
+        )
+      }
+
       return {
         schema: this.executableSchema,
         tracing: tracing(event),
@@ -93,7 +99,7 @@ export class GraphQLServerLambda {
         formatError: this.options.formatError,
         logFunction: this.options.logFunction,
         rootValue: this.options.rootValue,
-        validationRules: this.options.validationRules,
+        validationRules: this.options.validationRules as ValidationRules,
         fieldResolver: this.options.fieldResolver || customFieldResolver,
         formatParams: this.options.formatParams,
         formatResponse: this.options.formatResponse,

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,13 +52,20 @@ export interface TracingOptions {
   mode: 'enabled' | 'disabled' | 'http-header'
 }
 
+export type ValidationRules = Array<(context: ValidationContext) => any>
+
+export type ValidationRulesExpressCallback = (
+  request: Request,
+  response: Response,
+) => ValidationRules
+
 export interface ApolloServerOptions {
   tracing?: boolean | TracingOptions
   cacheControl?: boolean
   formatError?: Function
   logFunction?: LogFunction
   rootValue?: any
-  validationRules?: Array<(context: ValidationContext) => any>
+  validationRules?: ValidationRules | ValidationRulesExpressCallback
   fieldResolver?: GraphQLFieldResolver<any, any>
   formatParams?: Function
   formatResponse?: Function


### PR DESCRIPTION
I started playing with implementing complexity analysis and noticed I couldn't use yoga + the library I wanted ([graphql-cost-analysis](https://github.com/pa-bru/graphql-cost-analysis)).

Added example with measuring query complexity + did the required change in yoga to support it.


👯‍♂️  **Non-breaking change** 👯‍♂️