### PR TITLE
fix(server): make `start` method callback receive correct port info

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -329,7 +329,10 @@ export class GraphQLServer {
     return new Promise((resolve, reject) => {
       const combinedServer = server
       combinedServer.listen(this.options.port, () => {
-        callbackFunc(this.options)
+        callbackFunc({
+          ...this.options,
+          port: combinedServer.address().port,
+        })
         resolve(combinedServer)
       })
     })


### PR DESCRIPTION
Closes #259 