### PR TITLE
Added new tests for graphql-deduplicator

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,10 +1,13 @@
-import test from 'ava'
+import test, { TestContext, Context } from 'ava'
 import { inflate } from 'graphql-deduplicator'
-import { GraphQLServer } from './index'
+import { GraphQLServer, Options } from './index'
 import { promisify } from 'util'
 import * as request from 'request-promise-native'
 
-test.beforeEach('start hello world', async t => {
+async function startServer(
+  t: TestContext & Context<any>,
+  options?: Options
+) {
   const randomId = () => Math.random().toString(36).substr(2, 5)
 
   const typeDefs = `
@@ -46,24 +49,34 @@ test.beforeEach('start hello world', async t => {
   }
 
   const server = new GraphQLServer({ typeDefs, resolvers })
-
-  const http = await server.start({ port: 0 })
-
+  const http = await server.start({ port: 0, ...options })
   const { port } = http.address()
   const uri = `http://localhost:${port}/`
 
-  t.context.http = http
-  t.context.uri = uri
-  t.context.book = book
-})
+  if (t.context.httpServers) {
+    t.context.httpServers.push(http)
+  } else {
+    t.context.httpServers = [http]
+  }
 
-test.afterEach.always('stop hello world', async t => {
-  const { http } = t.context
-  await promisify(http.close).call(http)
+  t.context.uri = uri
+  t.context.data = { book }
+
+  return t.context
+}
+
+test.afterEach.always('stop graphql servers', async t => {
+  const { httpServers } = t.context
+
+  if (httpServers && httpServers.length) {
+    await Promise.all(
+      httpServers.map(server => promisify(server.close).call(server))
+    )
+  }
 })
 
 test('works with simple hello world server', async t => {
-  const { uri } = t.context
+  const { uri } = await startServer(t)
 
   const query = `
     query {
@@ -86,7 +99,7 @@ test('works with simple hello world server', async t => {
 })
 
 test('Response data can be deduplicated with graphql-deduplicator', async t => {
-  const { uri, book } = t.context
+  const { uri, data: { book } } = await startServer(t)
 
   const query = `
     query {
@@ -140,4 +153,42 @@ test('Response data can be deduplicated with graphql-deduplicator', async t => {
   })
 
   t.deepEqual(body.data, inflate(deduplicated.data))
+})
+
+test('graphql-deduplicated can be completely disabled', async t => {
+  const { uri, data: { book } } = await startServer(t, {
+    deduplicator: false
+  })
+
+  const query = `
+    query {
+      books {
+        __typename
+        id
+        name
+        author {
+          __typename
+          id
+          name
+          lastName
+        }
+      }
+    }
+  `
+
+  const body = await request({
+    uri,
+    method: 'POST',
+    json: true,
+    body: { query },
+    headers: {
+      'X-GraphQL-Deduplicate': true
+    }
+  }).promise()
+
+  t.deepEqual(body, {
+    data: {
+      books: Array(5).fill(book)
+    }
+  })
 })

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,18 +1,47 @@
 import test from 'ava'
+import { inflate } from 'graphql-deduplicator'
 import { GraphQLServer } from './index'
 import { promisify } from 'util'
 import * as request from 'request-promise-native'
 
 test.beforeEach('start hello world', async t => {
+  const randomId = () => Math.random().toString(36).substr(2, 5)
+
   const typeDefs = `
+    type Author {
+      id: ID!
+      name: String!
+      lastName: String!
+    }
+
+    type Book {
+      id: ID!
+      name: String!
+      author: Author!
+    }
+
     type Query {
-        hello(name: String): String!
+      hello(name: String): String!
+      books: [Book!]!
     }
     `
 
+  const author = {
+    __typename: 'Author',
+    id: randomId(),
+    name: 'Jhon',
+    lastName: 'Doe'
+  }
+  const book = {
+    __typename: 'Book',
+    id: randomId(),
+    name: 'Awesome',
+    author
+  }
   const resolvers = {
     Query: {
       hello: (_, { name }) => `Hello ${name || 'World'}`,
+      books: () => Array(5).fill(book)
     },
   }
 
@@ -25,6 +54,7 @@ test.beforeEach('start hello world', async t => {
 
   t.context.http = http
   t.context.uri = uri
+  t.context.book = book
 })
 
 test.afterEach.always('stop hello world', async t => {
@@ -53,4 +83,61 @@ test('works with simple hello world server', async t => {
       hello: 'Hello Sarah',
     },
   })
+})
+
+test('Response data can be deduplicated with graphql-deduplicator', async t => {
+  const { uri, book } = t.context
+
+  const query = `
+    query {
+      books {
+        __typename
+        id
+        name
+        author {
+          __typename
+          id
+          name
+          lastName
+        }
+      }
+    }
+  `
+
+  const body = await request({
+    uri,
+    method: 'POST',
+    json: true,
+    body: { query },
+  }).promise()
+
+  const deduplicated = await request({
+    uri,
+    method: 'POST',
+    json: true,
+    body: { query },
+    headers: {
+      'X-GraphQL-Deduplicate': true
+    }
+  }).promise()
+
+  t.deepEqual(body, {
+    data: {
+      books: Array(5).fill(book)
+    }
+  })
+
+  t.deepEqual(deduplicated, {
+    data: {
+      books: [
+        book,
+        ...Array(4).fill({
+          __typename: book.__typename,
+          id: book.id
+        })
+      ]
+    }
+  })
+
+  t.deepEqual(body.data, inflate(deduplicated.data))
 })


### PR DESCRIPTION
Now that the package is adding tests, here is a new test for [graphql-deduplicator](graphql-deduplicator), in this test the `data` is checked to be deduplicated if the client wants it.

I can also create a new test case for when the `deduplicator` option is set as `false`, in such case the response should never be deduplicated, if you think it's required let me know!